### PR TITLE
Parse header md level

### DIFF
--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -16,7 +16,7 @@ defmodule Markdown do
   def parse(m) do
     m
     |> String.split("\n")
-    |> Enum.map(fn t -> process(t) end)
+    |> Enum.map(& process(&1))
     |> Enum.join()
     |> patch()
   end

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -11,10 +11,14 @@ defmodule Markdown do
     "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"
   """
 
-  #This should probably be a pipeline instead of all those nested functions
+  #Refactored into a pipeline to get rid of the nested functions
   @spec parse(String.t()) :: String.t()
   def parse(m) do
-    patch(Enum.join(Enum.map(String.split(m, "\n"), fn t -> process(t) end)))
+    m
+    |> String.split("\n")
+    |> Enum.map(fn t -> process(t) end)
+    |> Enum.join()
+    |> patch()
   end
 
   #I removed the nested if structure and replaced it with 'case'"

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -13,8 +13,8 @@ defmodule Markdown do
 
   #Refactored into a pipeline to get rid of the nested functions
   @spec parse(String.t()) :: String.t()
-  def parse(m) do
-    m
+  def parse(markdown_text) do
+    markdown_text
     |> String.split("\n")
     |> Enum.map(& process(&1))
     |> Enum.join()
@@ -36,7 +36,6 @@ defmodule Markdown do
   defp parse_header_md_level(line) do
     [h | t] = String.split(line)
     {to_string(String.length(h)), Enum.join(t, " ")}
-    # {"number", "text minus the header markup"}
   end
 
   #changed the argument to "line" for the same reason as in the parse_header_md_function above. also changed "t" to "text"

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -31,7 +31,7 @@ defmodule Markdown do
     case String.first(line) do
       "#" -> enclose_with_header_tag(parse_header_md_level(line))
       "*" -> parse_list_md_level(line)
-      _ -> enclose_with_paragraph_tag(line)
+      _ -> enclose_with_paragraph_tag(String.split(line))
     end
   end
 
@@ -57,7 +57,7 @@ defmodule Markdown do
   end
 
   defp enclose_with_paragraph_tag(line) do
-    "<p>#{line}</p>"
+    "<p>#{join_words_with_tags(line)}</p>"
   end
 
   defp join_words_with_tags(t) do

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -17,7 +17,7 @@ defmodule Markdown do
     patch(Enum.join(Enum.map(String.split(m, "\n"), fn t -> process(t) end)))
   end
 
-
+  #I removed the nested if structure and replaced it with 'case'"
   defp process(t) do
     case String.first(t) do
       "#" -> enclose_with_header_tag(parse_header_md_level(t))
@@ -26,9 +26,12 @@ defmodule Markdown do
     end
   end
 
-  defp parse_header_md_level(hwt) do
-    [h | t] = String.split(hwt)
+  #decided to change the 'hwt' argument to 't' since it is still the original string that is being passed into this function
+  defp parse_header_md_level(t) do
+    [h | t] = String.split(t)
     {to_string(String.length(h)), Enum.join(t, " ")}
+    
+    # {"number", "text minus the header markup"}
   end
 
   defp parse_list_md_level(l) do

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -22,27 +22,29 @@ defmodule Markdown do
   end
 
   #I removed the nested if structure and replaced it with 'case'"
-  defp process(t) do
-    IO.inspect(t, label: "this is t")
-    case String.first(t) do
-      "#" -> enclose_with_header_tag(parse_header_md_level(t))
-      "*" -> parse_list_md_level(t)
-      _ -> enclose_with_paragraph_tag(String.split(t))
+  # changed 't' into 'line' because it is the result of String.split in the parse function
+  defp process(line) do
+    case String.first(line) do
+      "#" -> enclose_with_header_tag(parse_header_md_level(line))
+      "*" -> parse_list_md_level(line)
+      _ -> enclose_with_paragraph_tag(String.split(line))
     end
   end
 
-  #decided to change the 'hwt' argument to 't' since it is still the original string that is being passed into this function
-  defp parse_header_md_level(t) do
-    [h | t] = String.split(t)
+  #decided to change the 'hwt' argument to 'line' since it is still the line from the process function that gets passed in here
+  defp parse_header_md_level(line) do
+    [h | t] = String.split(line)
     {to_string(String.length(h)), Enum.join(t, " ")}
     |> IO.inspect(label: "output of parse_heder_md_level")
     # {"number", "text minus the header markup"}
   end
 
-  defp parse_list_md_level(l) do
-    IO.inspect(l, label: "Input to parse_list_md_level")
-    t = String.split(String.trim_leading(l, "* "))
-    "<li>" <> join_words_with_tags(t) <> "</li>"
+  #changed the argument to "line" for the same reason as in the parse_header_md_function above. also changed "t" to "text"
+  defp parse_list_md_level(line) do
+    IO.inspect(line, label: "Input to parse_list_md_level")
+    text = String.split(String.trim_leading(line, "* "))
+    IO.inspect(text, label: "This is text")
+    "<li>" <> join_words_with_tags(text) <> "</li>"
     |> IO.inspect(label: "parse_list_md_level output")
   end
 

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -16,11 +16,8 @@ defmodule Markdown do
   def parse(m) do
     m
     |> String.split("\n")
-    |> IO.inspect(label: "output of String.split")
     |> Enum.map(& process(&1))
-    |> IO.inspect(label: "Enum.map process output")
     |> Enum.join()
-    |> IO.inspect(label: "output of Enum.join")
     |> patch()
 
   end
@@ -39,54 +36,55 @@ defmodule Markdown do
   defp parse_header_md_level(line) do
     [h | t] = String.split(line)
     {to_string(String.length(h)), Enum.join(t, " ")}
-    |> IO.inspect(label: "output of parse_header_md_level")
     # {"number", "text minus the header markup"}
   end
 
   #changed the argument to "line" for the same reason as in the parse_header_md_function above. also changed "t" to "text"
   defp parse_list_md_level(line) do
-    IO.inspect(line, label: "Input to parse_list_md_level")
     text = String.split(String.trim_leading(line, "* "))
-    IO.inspect(text, label: "This is text")
     "<li>" <> join_words_with_tags(text) <> "</li>"
-    |> IO.inspect(label: "parse_list_md_level output")
   end
 
   defp enclose_with_header_tag({hl, htl}) do
     "<h" <> hl <> ">" <> htl <> "</h" <> hl <> ">"
   end
 
-  defp enclose_with_paragraph_tag(line) do
-    "<p>#{join_words_with_tags(line)}</p>"
+  #I changed the argument to split_line to reflect that it is the result of String.split(line) in the process(line) function
+  defp enclose_with_paragraph_tag(split_line) do
+    "<p>#{join_words_with_tags(split_line)}</p>"
   end
 
-  defp join_words_with_tags(t) do
-    Enum.join(Enum.map(t, fn w -> replace_md_with_tag(w) end), " ")
+  #I changed the argument to unsplit_text
+  defp join_words_with_tags(unsplit_text) do
+    Enum.join(Enum.map(unsplit_text, fn word -> replace_md_with_tag(word) end), " ")
+
   end
 
-  defp replace_md_with_tag(w) do
-    replace_suffix_md(replace_prefix_md(w))
+  #I changed the argument name from "w" to "word" everywhere
+  defp replace_md_with_tag(word) do
+    replace_suffix_md(replace_prefix_md(word))
   end
 
-  defp replace_prefix_md(w) do
+  defp replace_prefix_md(word) do
     cond do
-      w =~ ~r/^#{"__"}{1}/ -> String.replace(w, ~r/^#{"__"}{1}/, "<strong>", global: false)
-      w =~ ~r/^[#{"_"}{1}][^#{"_"}+]/ -> String.replace(w, ~r/_/, "<em>", global: false)
-      true -> w
+      word =~ ~r/^#{"__"}{1}/ -> String.replace(word, ~r/^#{"__"}{1}/, "<strong>", global: false)
+      word =~ ~r/^[#{"_"}{1}][^#{"_"}+]/ -> String.replace(word, ~r/_/, "<em>", global: false)
+      true -> word
     end
   end
 
-  defp replace_suffix_md(w) do
+  defp replace_suffix_md(word) do
     cond do
-      w =~ ~r/#{"__"}{1}$/ -> String.replace(w, ~r/#{"__"}{1}$/, "</strong>")
-      w =~ ~r/[^#{"_"}{1}]/ -> String.replace(w, ~r/_/, "</em>")
-      true -> w
+      word =~ ~r/#{"__"}{1}$/ -> String.replace(word, ~r/#{"__"}{1}$/, "</strong>")
+      word =~ ~r/[^#{"_"}{1}]/ -> String.replace(word, ~r/_/, "</em>")
+      true -> word
     end
   end
 
-  defp patch(l) do
+  #Once again changed "l" to "line" for more clarity
+  defp patch(line) do
     String.replace_suffix(
-      String.replace(l, "<li>", "<ul>" <> "<li>", global: false),
+      String.replace(line, "<li>", "<ul>" <> "<li>", global: false),
       "</li>",
       "</li>" <> "</ul>"
     )

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -16,9 +16,13 @@ defmodule Markdown do
   def parse(m) do
     m
     |> String.split("\n")
+    |> IO.inspect(label: "output of String.split")
     |> Enum.map(& process(&1))
+    |> IO.inspect(label: "Enum.map process output")
     |> Enum.join()
+    |> IO.inspect(label: "output of Enum.join")
     |> patch()
+
   end
 
   #I removed the nested if structure and replaced it with 'case'"
@@ -27,7 +31,7 @@ defmodule Markdown do
     case String.first(line) do
       "#" -> enclose_with_header_tag(parse_header_md_level(line))
       "*" -> parse_list_md_level(line)
-      _ -> enclose_with_paragraph_tag(String.split(line))
+      _ -> enclose_with_paragraph_tag(line)
     end
   end
 
@@ -35,7 +39,7 @@ defmodule Markdown do
   defp parse_header_md_level(line) do
     [h | t] = String.split(line)
     {to_string(String.length(h)), Enum.join(t, " ")}
-    |> IO.inspect(label: "output of parse_heder_md_level")
+    |> IO.inspect(label: "output of parse_header_md_level")
     # {"number", "text minus the header markup"}
   end
 
@@ -52,8 +56,8 @@ defmodule Markdown do
     "<h" <> hl <> ">" <> htl <> "</h" <> hl <> ">"
   end
 
-  defp enclose_with_paragraph_tag(t) do
-    "<p>#{join_words_with_tags(t)}</p>"
+  defp enclose_with_paragraph_tag(line) do
+    "<p>#{line}</p>"
   end
 
   defp join_words_with_tags(t) do

--- a/elixir/markdown/lib/markdown.ex
+++ b/elixir/markdown/lib/markdown.ex
@@ -19,6 +19,7 @@ defmodule Markdown do
 
   #I removed the nested if structure and replaced it with 'case'"
   defp process(t) do
+    IO.inspect(t, label: "this is t")
     case String.first(t) do
       "#" -> enclose_with_header_tag(parse_header_md_level(t))
       "*" -> parse_list_md_level(t)
@@ -30,13 +31,15 @@ defmodule Markdown do
   defp parse_header_md_level(t) do
     [h | t] = String.split(t)
     {to_string(String.length(h)), Enum.join(t, " ")}
-    
+    |> IO.inspect(label: "output of parse_heder_md_level")
     # {"number", "text minus the header markup"}
   end
 
   defp parse_list_md_level(l) do
+    IO.inspect(l, label: "Input to parse_list_md_level")
     t = String.split(String.trim_leading(l, "* "))
     "<li>" <> join_words_with_tags(t) <> "</li>"
+    |> IO.inspect(label: "parse_list_md_level output")
   end
 
   defp enclose_with_header_tag({hl, htl}) do

--- a/elixir/markdown/mix.exs
+++ b/elixir/markdown/mix.exs
@@ -21,8 +21,7 @@ defmodule Markdown.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:credo, "~> 1.5", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/elixir/markdown/mix.lock
+++ b/elixir/markdown/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.5.5", "e8f422026f553bc3bebb81c8e8bf1932f498ca03339856c7fec63d3faac8424b", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "dd8623ab7091956a855dc9f3062486add9c52d310dfd62748779c4315d8247de"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
+}

--- a/elixir/markdown/test/markdown_test.exs
+++ b/elixir/markdown/test/markdown_test.exs
@@ -8,7 +8,7 @@ defmodule MarkdownTest do
     assert Markdown.parse(input) == expected
   end
 
-   @tag :pending
+  # @tag :pending
   test "parsing italics" do
     input = "_This will be italic_"
     expected = "<p><em>This will be italic</em></p>"

--- a/elixir/markdown/test/markdown_test.exs
+++ b/elixir/markdown/test/markdown_test.exs
@@ -8,56 +8,56 @@ defmodule MarkdownTest do
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+   @tag :pending
   test "parsing italics" do
     input = "_This will be italic_"
     expected = "<p><em>This will be italic</em></p>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "parsing bold text" do
     input = "__This will be bold__"
     expected = "<p><strong>This will be bold</strong></p>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "mixed normal, italics and bold text" do
     input = "This will _be_ __mixed__"
     expected = "<p>This will <em>be</em> <strong>mixed</strong></p>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "with h1 header level" do
     input = "# This will be an h1"
     expected = "<h1>This will be an h1</h1>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "with h2 header level" do
     input = "## This will be an h2"
     expected = "<h2>This will be an h2</h2>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "with h6 header level" do
     input = "###### This will be an h6"
     expected = "<h6>This will be an h6</h6>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "unordered lists" do
     input = "* Item 1\n* Item 2"
     expected = "<ul><li>Item 1</li><li>Item 2</li></ul>"
     assert Markdown.parse(input) == expected
   end
 
-  # @tag :pending
+  @tag :pending
   test "with a little bit of everything" do
     input = "# Header!\n* __Bold Item__\n* _Italic Item_"
 


### PR DESCRIPTION
I have simplified some stuff and added comments in the code regarding what I did.

I feel that in order to simplify even more, I would have to change the whole process flow of the original code.
It seems to me that in the original version the code is checked for headers, list, paras first and then for highlighting.
If I was to set this up, I would probably do the highlighting first and then process the rest.

What are your thoughts?
How much else do you think I should do?
where do I start?